### PR TITLE
add logging interval in wandb as one optional parameter

### DIFF
--- a/cw2/cw_data/cw_wandb_logger.py
+++ b/cw2/cw_data/cw_wandb_logger.py
@@ -105,6 +105,12 @@ class WandBLogger(cw_logging.AbstractLogger):
 
     def process(self, data: dict) -> None:
         if self.run is not None:
+
+            # Skip logging if interval is defined but not satisfied
+            log_interval = self.config.get("log_interval", None)
+            if log_interval is not None and data["iter"] % log_interval != 0:
+                return
+
             if "histogram" in self.config:
                 for el in self.config.histogram:
                     if el in data:


### PR DESCRIPTION
Hi,

I added a small feature in wandb logger to log stuff in a given interval.

This makes sure the logging is not happening in each iteration, which is helpful in the case where a small dataset is used and the web browser of wandb may be slow due to too much logged data.