### PR TITLE
Feature/non daemonic processes in scheduler

### DIFF
--- a/cw2/cw_config/cw_conf_keys.py
+++ b/cw2/cw_config/cw_conf_keys.py
@@ -33,3 +33,6 @@ i_REP_LOG_PATH = "_rep_log_path"
 # INTERNAL IMPORT ARCHIVE
 i_IMPORT_PATH_ARCHIVE = "_import_path_archive"
 i_IMPORT_EXP_ARCHIVE = "_import_exp_archive"
+
+# CPU CORES ASSIGNMENT
+i_CPU_CORES = "cpu_cores"

--- a/cw2/scheduler.py
+++ b/cw2/scheduler.py
@@ -158,8 +158,8 @@ class HOREKAAffinityGPUDistributingLocalScheduler(GPUDistributingLocalScheduler)
                                                                                                  self._gpus_per_rep,
                                                                                                  self._cpus_per_rep,
                                                                                                  overwrite))
-            pool.close()
-            pool.join()
+            # pool.close()
+            # pool.join()
 
     @staticmethod
     def _execute_task(j: job.Job,

--- a/cw2/scheduler.py
+++ b/cw2/scheduler.py
@@ -1,4 +1,5 @@
 import abc
+import concurrent.futures
 import os
 from typing import List
 
@@ -143,7 +144,8 @@ class HOREKAAffinityGPUDistributingLocalScheduler(GPUDistributingLocalScheduler)
             assert j.n_parallel == self._queue_elements, "Mismatch between GPUs Queue Elements and Jobs executed in" \
                                                          "parallel. Fix for optimal resource usage!!"
 
-        with multiprocessing.Pool(processes=num_parallel) as pool:
+        # with multiprocessing.Pool(processes=num_parallel) as pool:
+        with concurrent.futures.ProcessPoolExecutor(max_workers=num_parallel) as pool:
             # setup gpu resource queue
             m = multiprocessing.Manager()
             gpu_queue = m.Queue(maxsize=self._queue_elements)

--- a/cw2/scheduler.py
+++ b/cw2/scheduler.py
@@ -10,6 +10,7 @@ import warnings
 from cw2 import cw_error, job
 from cw2.cw_config import cw_config
 from cw2.cw_slurm import cw_slurm
+from cw2.cw_config import cw_conf_keys as KEYS
 
 
 class AbstractScheduler(abc.ABC):
@@ -172,7 +173,8 @@ class HOREKAAffinityGPUDistributingLocalScheduler(GPUDistributingLocalScheduler)
         cpus = set(range(queue_idx * cpus_per_rep, (queue_idx + 1) * cpus_per_rep))
         print("Job {}: Using GPUs: {} and CPUs: {}".format(queue_idx, gpu_str, cpus))
         try:
-            # os.sched_setaffinity(0, cpus)
+            os.sched_setaffinity(0, cpus)
+            c[KEYS.i_CPU_CORES] = cpus
             os.environ["CUDA_VISIBLE_DEVICES"] = gpu_str
             j.run_task(c, overwrite)
         except cw_error.ExperimentSurrender as _:

--- a/cw2/scheduler.py
+++ b/cw2/scheduler.py
@@ -154,7 +154,7 @@ class HOREKAAffinityGPUDistributingLocalScheduler(GPUDistributingLocalScheduler)
 
             for j in self.joblist:
                 for c in j.tasks:
-                    pool.apply_async(HOREKAAffinityGPUDistributingLocalScheduler._execute_task, (j, c, gpu_queue,
+                    pool.map(HOREKAAffinityGPUDistributingLocalScheduler._execute_task, (j, c, gpu_queue,
                                                                                                  self._gpus_per_rep,
                                                                                                  self._cpus_per_rep,
                                                                                                  overwrite))

--- a/cw2/scheduler.py
+++ b/cw2/scheduler.py
@@ -145,8 +145,7 @@ class HOREKAAffinityGPUDistributingLocalScheduler(GPUDistributingLocalScheduler)
                                                          "parallel. Fix for optimal resource usage!!"
 
         with concurrent.futures.ProcessPoolExecutor(max_workers=num_parallel,
-                                                    ) as pool:  # Bruce
-            # with multiprocessing.Pool(processes=num_parallel) as pool:
+                                                    ) as pool:
             # setup gpu resource queue
             m = multiprocessing.Manager()
             gpu_queue = m.Queue(maxsize=self._queue_elements)
@@ -159,14 +158,6 @@ class HOREKAAffinityGPUDistributingLocalScheduler(GPUDistributingLocalScheduler)
                         HOREKAAffinityGPUDistributingLocalScheduler._execute_task,
                         j, c, gpu_queue, self._gpus_per_rep, self._cpus_per_rep,
                         overwrite)
-                #     pool.apply_async(
-                # HOREKAAffinityGPUDistributingLocalScheduler._execute_task,
-                # (j, c, gpu_queue, self._gpus_per_rep,
-                #  self._cpus_per_rep,
-                #  overwrite))
-
-                # pool.close()
-                # pool.join()
 
     @staticmethod
     def _execute_task(j: job.Job,

--- a/cw2/scheduler.py
+++ b/cw2/scheduler.py
@@ -172,7 +172,7 @@ class HOREKAAffinityGPUDistributingLocalScheduler(GPUDistributingLocalScheduler)
         cpus = set(range(queue_idx * cpus_per_rep, (queue_idx + 1) * cpus_per_rep))
         print("Job {}: Using GPUs: {} and CPUs: {}".format(queue_idx, gpu_str, cpus))
         try:
-            os.sched_setaffinity(0, cpus)
+            # os.sched_setaffinity(0, cpus)
             os.environ["CUDA_VISIBLE_DEVICES"] = gpu_str
             j.run_task(c, overwrite)
         except cw_error.ExperimentSurrender as _:


### PR DESCRIPTION
Solved these problems in the Horeka cluster:

1. The scheduled experiment, as a daemonic process, cannot generate other daemonic processes, which does not allow online reinforcement learning usage, where the agent (primary process) will spawn a few environments in the form of other daemonic processes. 
2. Low CPU resource usage for a GPU node, when running multiple repetitions with online RL in parallel. This is because the cw2 currently can only assign a certain number of CPU cores to the experiment (primary process), but cannot assign the CPU cores to the further generated environment processes. 

Solutions:
1. Use the concurrent package's process pool instead of the multiprocessing pool in the HorekaGPU scheduler.
2. Write the set of CPU cores assigned to the experiment into the cw_config dictionary, so that the people can take these cores and manually bundle the environment process to a certain CPU and thus avoid conflict.
3. Add the document as chapter 10.3.