### PR TITLE
Feature/horeka many reps per cpu node

### DIFF
--- a/cw2/cluster_work.py
+++ b/cw2/cluster_work.py
@@ -68,6 +68,10 @@ class ClusterWork:
                 if scheduler.GPUDistributingLocalScheduler.use_distributed_gpu_scheduling(self.config):
                     scheduler_cls = scheduler.get_gpu_scheduler_cls(self.config.slurm_config.get("scheduler", "mp"))
                     s = scheduler_cls(self.config)
+
+                elif scheduler.CpuDistributingLocalScheduler.use_distributed_cpu_scheduling(self.config):
+                    s = scheduler.CpuDistributingLocalScheduler(self.config)
+
                 else:
                     s = scheduler.LocalScheduler()
             else:

--- a/cw2/scheduler.py
+++ b/cw2/scheduler.py
@@ -307,7 +307,9 @@ class CpuDistributingLocalScheduler(AbstractScheduler):
     def use_distributed_cpu_scheduling(conf: cw_config.Config) -> bool:
         if conf.slurm_config is None:
             return False
-        return conf.slurm_config['scheduler'] == 'cpu_distribute'
+        else:
+            scheduler = conf.slurm_config.get('scheduler', None)
+            return scheduler == 'cpu_distribute'
 
 class LocalScheduler(AbstractScheduler):
     def run(self, overwrite: bool = False):

--- a/cw2/scheduler.py
+++ b/cw2/scheduler.py
@@ -260,6 +260,7 @@ class CpuDistributingLocalScheduler(AbstractScheduler):
         self._queue_elements = int(self._total_num_cpus / self._cpus_per_rep)
         print("CPUDistributingLocalScheduler: {} CPUs available, {} CPUs per rep, {} queue elements".format(
             self._total_num_cpus, self._cpus_per_rep, self._queue_elements))
+
     def run(self, overwrite: bool = False):
         print("Seeing CPUs:", os.sched_getaffinity(0))
         num_parallel = self.joblist[0].n_parallel

--- a/cw2/scheduler.py
+++ b/cw2/scheduler.py
@@ -251,6 +251,63 @@ def get_gpu_scheduler_cls(scheduler: str):
         raise NotImplementedError
 
 
+class CpuDistributingLocalScheduler(AbstractScheduler):
+    def __init__(self, conf: cw_config.Config = None):
+        super(CpuDistributingLocalScheduler, self).__init__(conf=conf)
+        self._total_num_cpus = conf.slurm_config['cpus-per-task'] * conf.slurm_config['ntasks']
+        self._cpus_per_rep = conf.slurm_config['cpus_per_rep']
+        assert self._cpus_per_rep == int(self._cpus_per_rep), "cpus_per_rep must be integer"
+        self._queue_elements = int(self._total_num_cpus / self._cpus_per_rep)
+        print("CPUDistributingLocalScheduler: {} CPUs available, {} CPUs per rep, {} queue elements".format(
+            self._total_num_cpus, self._cpus_per_rep, self._queue_elements))
+    def run(self, overwrite: bool = False):
+        print("Seeing CPUs:", os.sched_getaffinity(0))
+        num_parallel = self.joblist[0].n_parallel
+        for j in self.joblist:
+            assert j.n_parallel == num_parallel, "All jobs in list must have same n_parallel"
+            assert j.n_parallel == self._queue_elements, "Mismatch between CPUs Queue Elements and Jobs executed in" \
+                                                         "parallel. Fix for optimal resource usage!!"
+
+        with concurrent.futures.ProcessPoolExecutor(max_workers=num_parallel,
+                                                    ) as pool:
+            # setup gpu resource queue
+            m = multiprocessing.Manager()
+            cpu_queue = m.Queue(maxsize=self._queue_elements)
+            for i in range(self._queue_elements):
+                cpu_queue.put(i)
+
+            for j in self.joblist:
+                for c in j.tasks:
+                    pool.submit(
+                        CpuDistributingLocalScheduler._execute_task,
+                        j, c, cpu_queue, self._cpus_per_rep,
+                        overwrite)
+
+    @staticmethod
+    def _execute_task(j: job.Job,
+                      c: dict,
+                      q: multiprocessing.Queue,
+                      cpus_per_rep: int,
+                      overwrite: bool = False):
+        print("Seeing CPUs:", os.sched_getaffinity(0))
+        queue_idx = q.get()
+        cpus = set(range(queue_idx * cpus_per_rep, (queue_idx + 1) * cpus_per_rep))
+        print("Job {}: Using CPUs: {}".format(queue_idx, cpus))
+        try:
+            os.sched_setaffinity(0, cpus)
+            c[KEYS.i_CPU_CORES] = cpus
+            j.run_task(c, overwrite)
+        except cw_error.ExperimentSurrender as _:
+            return
+        finally:
+            q.put(queue_idx)
+
+    @staticmethod
+    def use_distributed_cpu_scheduling(conf: cw_config.Config) -> bool:
+        if conf.slurm_config is None:
+            return False
+        return conf.slurm_config['scheduler'] == 'cpu_distribute'
+
 class LocalScheduler(AbstractScheduler):
     def run(self, overwrite: bool = False):
         for j in self.joblist:


### PR DESCRIPTION
Run multiple reps in one CPU node, if the experiment is relatively smaller but needs a lot of random seed.
Similar behavior to the GPU distributing scheduler.