### PR TITLE
Transformed `group_id` option into `prefix_with_timestamp` (`-t`), which...

### DIFF
--- a/cw2/cli_parser.py
+++ b/cw2/cli_parser.py
@@ -40,8 +40,8 @@ class Arguments:
             action="store_true",
             default=False,
             help="If specified, prefix all started experiment runs with this timestamp. "
-                 "This can help with telling runs apart from one another, "
-                 "but will also modify the log directiories created.",
+                 "This can help with telling runs apart from one another. but will also modify the log "
+                 "directiories created. CAUTION: Only works with local schedulers (no SLURM etc.)",
         )
         p.add_argument("--nocodecopy", action="store_true", help="Skip code copy.")
         p.add_argument(
@@ -73,6 +73,11 @@ class Arguments:
         )
 
         self.args = p.parse_args(namespace=self)
+        if self.args.slurm and self.args.prefix_with_timestamp:
+            raise ValueError(
+                "Timestep prefixing (-t) only work on local schedulers, "
+                "so cannot use args --slurm (-s) and --prefix-with-timestamp (-t) at the same time."
+            )
 
     def get(self) -> dict:
         return vars(self.args)

--- a/cw2/cli_parser.py
+++ b/cw2/cli_parser.py
@@ -33,6 +33,16 @@ class Arguments:
         p.add_argument(
             "-o", "--overwrite", action="store_true", help="Overwrite existing results."
         )
+        p.add_argument(
+            "-t",
+            "--prefix-with-timestamp",
+            dest="prefix_with_timestamp",
+            action="store_true",
+            default=False,
+            help="If specified, prefix all started experiment runs with this timestamp. "
+                 "This can help with telling runs apart from one another, "
+                 "but will also modify the log directiories created.",
+        )
         p.add_argument("--nocodecopy", action="store_true", help="Skip code copy.")
         p.add_argument(
             "--zip", action="store_true", help="Make a Zip Copy of the Code."
@@ -60,13 +70,6 @@ class Arguments:
             action="store_true",
             default=False,
             help="Enable debug mode for arguments.",
-        )
-        p.add_argument(
-            "--add-group-id",
-            dest="add_group_id",
-            action="store_true",
-            default=False,
-            help="Add global group ID (timestamp str) to each run config",
         )
 
         self.args = p.parse_args(namespace=self)

--- a/cw2/cluster_work.py
+++ b/cw2/cluster_work.py
@@ -14,7 +14,7 @@ class ClusterWork:
             self.args["experiments"],
             self.args["debug"],
             self.args["debugall"],
-            self.args["add_group_id"]
+            self.args["prefix_with_timestamp"]
         )
 
         self.logArray = cw_logging.LoggerArray()

--- a/cw2/cw_config/cw_config.py
+++ b/cw2/cw_config/cw_config.py
@@ -14,7 +14,7 @@ class Config:
         experiment_selections: List[str] = None,
         debug: bool = False,
         debug_all: bool = False,
-        add_group_id: bool = False
+        prefix_with_timestamp: bool = False
     ):
         self.slurm_config = None
         self.exp_configs = None
@@ -23,7 +23,7 @@ class Config:
         self.config_path = config_path
         self.exp_selections = experiment_selections
 
-        self.add_group_id = add_group_id
+        self.prefix_with_timestamp = prefix_with_timestamp
 
         if config_path is not None:
             self.load_config(config_path, experiment_selections, debug, debug_all)
@@ -100,8 +100,11 @@ class Config:
             config_path, experiment_selections
         )
 
-        if self.add_group_id:
-            default_config["group_id"] = datetime.now().strftime("%y%m%d-%H%M%S")
+        # if desired, prefix experiments with timestamp
+        if self.prefix_with_timestamp:
+            experiment_start = datetime.now().strftime("%m%d-%H%M%S")
+            for exp_config in experiment_configs:
+                exp_config.update(name=f"{experiment_start}_{exp_config['name']}")
 
         experiment_configs = conf_resolver.resolve_dependencies(
             default_config, experiment_configs, self.config_path


### PR DESCRIPTION
..., prefixes experiment names with a timestamp of the creation. Implements #78 